### PR TITLE
fix: resolve paths from package location, not cwd

### DIFF
--- a/cli/lib/commands/setup.js
+++ b/cli/lib/commands/setup.js
@@ -16,7 +16,7 @@ import {
   validateIP,
   validateHostname
 } from '../validators.js';
-import { getLocalIP } from '../utils.js';
+import { getLocalIP, getProjectRoot } from '../utils.js';
 
 /**
  * Setup command - Interactive wizard for configuration
@@ -124,8 +124,8 @@ function createDefaultConfig() {
     },
     devices: [],
     paths: {
-      voiceApp: path.resolve(process.cwd(), 'voice-app'),
-      claudeApiServer: path.resolve(process.cwd(), 'claude-api-server')
+      voiceApp: path.join(getProjectRoot(), 'voice-app'),
+      claudeApiServer: path.join(getProjectRoot(), 'claude-api-server')
     }
   };
 }

--- a/cli/lib/utils.js
+++ b/cli/lib/utils.js
@@ -1,5 +1,30 @@
 import os from 'os';
+import path from 'path';
 import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/**
+ * Get the project root directory (where voice-app and claude-api-server live)
+ * This resolves from the CLI package location, not process.cwd()
+ *
+ * Directory structure:
+ *   claude-phone/           <- project root (returned)
+ *   ├── cli/
+ *   │   └── lib/
+ *   │       └── utils.js    <- this file
+ *   ├── voice-app/
+ *   └── claude-api-server/
+ *
+ * @returns {string} Absolute path to project root
+ */
+export function getProjectRoot() {
+  // utils.js is at cli/lib/utils.js
+  // Project root is two levels up: cli/lib -> cli -> project root
+  return path.resolve(__dirname, '..', '..');
+}
 
 /**
  * Get local IP address (best guess)

--- a/cli/test/path-resolution.test.js
+++ b/cli/test/path-resolution.test.js
@@ -1,0 +1,40 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// Import the function we need to test
+import { getProjectRoot } from '../lib/utils.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+test('path resolution', async (t) => {
+  await t.test('getProjectRoot returns project root regardless of cwd', () => {
+    // The project root should be one level up from cli/
+    // cli/test/path-resolution.test.js -> ../../../ = project root
+    const expectedRoot = path.resolve(__dirname, '..', '..');
+    const projectRoot = getProjectRoot();
+
+    assert.strictEqual(projectRoot, expectedRoot,
+      `Expected project root to be ${expectedRoot}, got ${projectRoot}`);
+  });
+
+  await t.test('getProjectRoot finds voice-app directory', () => {
+    const projectRoot = getProjectRoot();
+    const voiceAppPath = path.join(projectRoot, 'voice-app');
+
+    // The path should NOT contain /cli/voice-app
+    assert.ok(!voiceAppPath.includes('/cli/voice-app'),
+      `Path should not include /cli/voice-app: ${voiceAppPath}`);
+  });
+
+  await t.test('getProjectRoot finds claude-api-server directory', () => {
+    const projectRoot = getProjectRoot();
+    const apiServerPath = path.join(projectRoot, 'claude-api-server');
+
+    // The path should NOT contain /cli/claude-api-server
+    assert.ok(!apiServerPath.includes('/cli/claude-api-server'),
+      `Path should not include /cli/claude-api-server: ${apiServerPath}`);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes path resolution bug where `claude-phone setup` would fail when run from any directory other than the project root
- Adds `getProjectRoot()` helper that resolves paths relative to the CLI package location, not `process.cwd()`
- Adds test coverage for path resolution

## Problem
When users run `claude-phone setup` from their home directory (or anywhere other than the repo), the config would incorrectly set paths like `~/voice-app` instead of `/path/to/claude-phone/voice-app`.

## Solution
Resolve paths from the CLI package location using `import.meta.url` to find where the code actually lives.

## Test plan
- [x] Run `claude-phone setup` from project root - paths resolve correctly
- [x] Run `claude-phone setup` from home directory - paths still resolve correctly
- [x] Run `node --test cli/test/path-resolution.test.js` - all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)