### PR TITLE
Feature #15: Ask for ElevenLabs voice ID immediately after API key

### DIFF
--- a/cli/lib/commands/device/add.js
+++ b/cli/lib/commands/device/add.js
@@ -75,6 +75,7 @@ export async function deviceAddCommand() {
       type: 'input',
       name: 'voiceId',
       message: 'ElevenLabs voice ID:',
+      default: config.api.elevenlabs.defaultVoiceId || '',
       validate: (input) => {
         if (!input || input.trim() === '') {
           return 'Voice ID cannot be empty';


### PR DESCRIPTION
## Summary
Improves UX by asking for ElevenLabs voice ID immediately after the API key, grouping related configuration together.

## Changes
- Voice ID now prompted right after ElevenLabs API key validation
- Added `config.api.elevenlabs.defaultVoiceId` to store the default
- `setupDevice()` uses default voice ID as starting value
- `device add` command also uses the default

## New Flow
```
📡 API Configuration
  ElevenLabs API key: ****
  ✓ API key validated
  ElevenLabs voice ID: ****     ← NEW - immediately after
  ✓ Voice ID validated: Rachel
  OpenAI API key: ****
  ✓ API key validated
```

## Test plan
- [x] All 96 CLI tests pass
- [x] Voice ID validation works with fresh API key
- [x] Default carries over to device setup
- [x] Multi-device override still works

Fixes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)